### PR TITLE
Make the header of the table sticky

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -65,6 +65,20 @@ td:first-child {
   text-align: right;
 }
 
+/* Sticky header for the table. */
+th {
+    background: #333333;
+    box-shadow: 0px 2px 2px 0px rgb(0, 0, 0, 25%);
+    padding: 4px 2px;
+    position: -webkit-sticky;
+    position: sticky;
+    z-index: 1; /* Show on top of table cells. */
+    top: 0; /* Stick to the top of the screen. */
+}
+th:first-child {
+  border-left: 1px solid #333333; /* Fixes left border during scroll; must have a valid color, transparent doesn't work. */
+}
+
 .completion-complete {
   color: var(--completion-complete-color);
 }


### PR DESCRIPTION
It's a really long table 🙂 

Should look like this afterwards:
![image](https://user-images.githubusercontent.com/11782833/97908954-7740e000-1d58-11eb-82bc-3a9a532a2f4f.png)

Had to add a box shadow because the border is uncooperative if we set it to collapse on the table. It only looks slightly weird when not sticky. Not sure if we can target sticky/not-sticky states separately.