### PR TITLE
GitHub Actions: Update Hugo to 0.86.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Generate class reference table and build website
         env:
-          HUGO_VERSION: '0.83.0'
+          HUGO_VERSION: '0.86.0'
         run: |
           curl -LO "https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz"
           tar xf "hugo_${HUGO_VERSION}_Linux-64bit.tar.gz" hugo


### PR DESCRIPTION
We have to push a commit every 3 months to prevent GitHub Actions from being suspended, so let's do an Hugo update :slightly_smiling_face: 