### PR TITLE
Use `NO_COLOR` environment variable for `doc_status.py`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ EOF
 
 # Trim the first line of the output to get a valid Markdown table.
 # Ensure that module and platform documentation is also included in the report.
-python3 "$GODOT_TMP_DIR/doc/tools/doc_status.py" -u "$GODOT_TMP_DIR/doc/classes" "$GODOT_TMP_DIR"/modules/*/doc_classes "$GODOT_TMP_DIR"/platform/*/doc_classes | tail -n +2 >> content/_index.md
+NO_COLOR=1 python3 "$GODOT_TMP_DIR/doc/tools/doc_status.py" -u "$GODOT_TMP_DIR/doc/classes" "$GODOT_TMP_DIR"/modules/*/doc_classes "$GODOT_TMP_DIR"/platform/*/doc_classes | tail -n +2 >> content/_index.md
 
 # Fade out `0/0` completion ratios as they can't be completed (there's nothing to document).
 sed -i 's:0/0:<span style="opacity\: 0.3">0/0</span>:g' content/_index.md


### PR DESCRIPTION
Further to issue #29 , ANSI color codes were added by default to the output of `doc/tools/doc_status.py` over at the engine repo, thereby mangling the status table.

This PR uses the new, optional `NO_COLOR` environment variable from godotengine/godot#104524 to disable ANSI color codes.

Thanks! 😄 